### PR TITLE
Omit NAs in cov calc

### DIFF
--- a/stats/m_dist.m
+++ b/stats/m_dist.m
@@ -36,6 +36,12 @@ function  D = m_dist(data,fs, smoothDur, overlap, consec, cumSum, expStart, expE
 %  baselineEnd: End time (in seconds since start of the data set) of the baseline period.  
 %     If not specified, the entire data set will be used (baseline_end will 
 %     be the last sampled time-point in the data set).
+%  BL_COV: Logical. if TRUE, the variance-covariance matrix for Mahalanobis
+%     distance calculation is estimated based on the baseline period only. 
+%     If FALSE, estimate is based on the entire dataset. Default is FALSE. 
+%     If using TRUE, be sure you are confident that the baseline period is 
+%     long enough to provide adequate data for accurate estimation of the 
+%     matrix.
 %       
 % Outputs:
 %  D: Data structure containing results

--- a/stats/m_dist.m
+++ b/stats/m_dist.m
@@ -1,4 +1,4 @@
-function D = m_dist(data,fs, smoothDur, overlap, consec, cumSum, expStart, expEnd, baselineStart, baselineEnd, BL_COV)
+function  D = m_dist(data,fs, smoothDur, overlap, consec, cumSum, expStart, expEnd, baselineStart, baselineEnd, BL_COV)
 % Calculate Mahalanobis distance for a multivariate time series.
 %
 % Inputs: 
@@ -94,13 +94,13 @@ k = (1:N)';                                        %index vector
 ss = (k-1)*(W-O) + 1;                              %start times of comparison windows, in samples
 ps = ((k-1)*(W-O) + 1) + smoothDur.*fs.*60/2;      %mid points of comparison windows, in samples (times at which distances will be reported)
 t = ps/fs;                                         %mid-point times in seconds
-ctr = mean(data(bs:be,:), 1);                      %mean values during baseline period
+ctr = mean(data(bs:be,:), 1, 'omitnan');           %mean values during baseline period
 
 if BL_COV
     %covariance matrix using all data in baseline period
     bcov = cov(data(bs:be, :));
 else
-    bcov = cov(data);
+    bcov = cov(data, 'partialrows');
 end
 
 if consec == false

--- a/stats/m_dist.m
+++ b/stats/m_dist.m
@@ -20,7 +20,7 @@ function  D = m_dist(data,fs, smoothDur, overlap, consec, cumSum, expStart, expE
 %  consec: Logical. If consec=true, then the calculated distances are between
 %     consecutive windows of duration smoothDur, sliding forward over 
 %     the data set by a time step of (smoothDur-overlap) minutes.  
-%     If TRUE, baselineStart and baselineEnd inputs will be used to define
+%     If FALSE, baselineStart and baselineEnd inputs will be used to define
 %     the period used to calculate the data covariance matrix. Default is consec=false.  
 %  cumSum: Logical.  If cum_sum=true, then output will be the cumulative 
 %     sum of the calculated distances, rather than the distances themselves. 
@@ -47,7 +47,7 @@ function  D = m_dist(data,fs, smoothDur, overlap, consec, cumSum, expStart, expE
 %  D: Data structure containing results
 %     t: Times, in seconds since start of dataset, at which Mahalanobis distances are 
 %        reported. If a smoothDur was applied, then the reported times will be the 
-%        start times of each "comparison" window.
+%        mid points of each "comparison" window.
 %     dist: Mahalanobis distances between the specified baseline period and 
 %        the specified "comparison" periods             
 
@@ -176,7 +176,7 @@ function D = Ma(d, Sx)
 %   D: Data structure containing results
 %     t: Times, in seconds since start of dataset, at which Mahalanobis distances are 
 %        reported. If a smoothDur was applied, then the reported times will be the 
-%        start times of each "comparison" window.
+%        mid points of each "comparison" window.
 %     dist: Mahalanobis distances between the specified baseline period and 
 %        the specified "comparison" periods
 


### PR DESCRIPTION
Hi tagtools team,

I ran into an issue with `m_dist` when I had NAs in my tag data. I made two small changes to deal with this. I checked in with @stacyderuiter via email and sounds like this is an ok approach. I also saw that NAs were omitted in the `tagtools_r` version of `m_dist` in this same way so hopefully this makes the two packages more consistent. 

Selene